### PR TITLE
Fix playground link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <div>
   <p align="center">
-    <a href="https://antonioru.github.io/beautiful-react-diagrams/" target="_blank">
+    <a href="https://beautifulinteractions.github.io/beautiful-react-diagrams/" target="_blank">
     🌟 Live playground here 🌟
     </a>
   </p>


### PR DESCRIPTION
## Description

I just noticed that the link to the playground was broken in the README.