### PR TITLE
Prevents automated publishing to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
+      - uses: gregoranders/nodejs-project-info@v0.0.11
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
@@ -45,12 +46,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare distribution
+        if: "contains(steps.projectinfo.outputs.version, '-')"
         run: cp -r ./@types ./dist/@types && cp package.json index.d.ts README.md LICENSE CHANGELOG.md CONTRIBUTING.md CODE_OF_CONDUCT.md ./dist
 
       - name: Publish
+        if: "contains(steps.projectinfo.outputs.version, '-')"
         run: |
           npm pack
-          npm publish
+          npm publish --tag next
         working-directory: ./dist
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![CI/CD](https://github.com/antonioru/beautiful-react-diagrams/workflows/CI/CD/badge.svg)
+![CI/CD](https://github.com/beautifulinteractions/beautiful-react-diagrams/workflows/CI/CD/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Coverage Status](https://coveralls.io/repos/github/antonioru/beautiful-react-diagrams/badge.svg?branch=master)](https://coveralls.io/github/antonioru/beautiful-react-diagrams?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/beautifulinteractions/beautiful-react-diagrams/badge.svg?branch=master)](https://coveralls.io/github/antonioru/beautiful-react-diagrams?branch=master)
 ![npm](https://img.shields.io/npm/v/beautiful-react-diagrams)
-![GitHub stars](https://img.shields.io/github/stars/antonioru/beautiful-react-diagrams?style=social)
+![GitHub stars](https://img.shields.io/github/stars/beautifulinteractions/beautiful-react-diagrams?style=social)
 
 <div align="center">
   <p align="center">
@@ -69,6 +69,14 @@ To submit your custom pull request, please make sure your read our [CONTRIBUTING
 3. make sure you run `npm run lint`, `npm build` and then `npm test` before submitting your merge request.
 4. make sure you've added the documentation of your changes.
 5. if you've changed the signature of a component, please make sure you've updated the `index.d.ts` file.
+
+## Versioning
+
+This library follows the [semver](https://semver.org) versioning standard.
+Pre-release commits on the `master` branch, including merge commits, lead 
+to automated publication to NPM under the `next` tag. Pre-release version
+numbers must follow the `<major>.<minor>.<patch>-<tag>.<number>`, such as 
+`5.1.0-rc.0`. 
 
 ### Credits
 


### PR DESCRIPTION
This PR changes the GitHub Actions configuration file to prevent automated publishing to NPM unless the version contains a dash (e.g. `5.1.0-rc.1`). Furthermore, this PR constrains automated publishing to NPM to the `next` tag.

The reason behind this PR is to ensure that all versions meant to become the new `latest` on NPM (and therefore installed by default) are always reviewed by a human.

