### PR TITLE
Add touch support. Replaces PR #67

### DIFF
--- a/src/components/Diagram/Link/getEntityCoordinates.js
+++ b/src/components/Diagram/Link/getEntityCoordinates.js
@@ -13,8 +13,10 @@ const getEntityCoordinates = (entity, portRefs, nodeRefs, canvas) => {
   if (portRefs && portRefs[entity.entity.id]) {
     const portEl = portRefs[entity.entity.id];
     const bbox = portEl.getBoundingClientRect();
-
-    return getRelativePoint([bbox.x + (bbox.width / 2), bbox.y + (bbox.height / 2)], [canvas.x, canvas.y]);
+    return getRelativePoint(
+      { x: bbox.x + (bbox.width / 2), y: bbox.y + (bbox.height / 2) },
+      { x: canvas.x, y: canvas.y },
+    );
   }
 
   return undefined;

--- a/src/components/Diagram/Port/Port.js
+++ b/src/components/Diagram/Port/Port.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import useDrag from '../../../shared/internal_hooks/useDrag';
 import useCanvas from '../../../shared/internal_hooks/useCanvas';
 import getRelativePoint from '../../../shared/functions/getRelativePoint';
-
+import { getEventPoint, getEventTarget } from '../../../shared/Constants';
 /**
  * Port
  * @param props
@@ -19,16 +19,15 @@ const Port = (props) => {
     if (onDragNewSegment) {
       event.stopImmediatePropagation();
       event.stopPropagation();
-      const from = getRelativePoint(info.start, [canvas.x, canvas.y]);
-      const to = getRelativePoint([event.clientX, event.clientY], [canvas.x, canvas.y]);
-
+      const from = getRelativePoint(info.start, { x: canvas.x, y: canvas.y });
+      const to = getRelativePoint(getEventPoint(event), { x: canvas.x, y: canvas.y });
       onDragNewSegment(id, from, to, alignment);
     }
   });
 
   onDragEnd((event) => {
-    const targetPort = event.target.getAttribute('data-port-id');
-    if (targetPort && event.target !== ref.current && canLink(id, targetPort, type) && onSegmentConnect) {
+    const targetPort = getEventTarget(event).getAttribute('data-port-id');
+    if (targetPort && getEventTarget(event) !== ref.current && canLink(id, targetPort, type) && onSegmentConnect) {
       const args = type === 'input' ? [id, targetPort, type] : [targetPort, id, type];
 
       onSegmentConnect(...args);

--- a/src/shared/Constants.js
+++ b/src/shared/Constants.js
@@ -2,6 +2,17 @@ export const isTouch = 'ontouchstart' in window;
 
 export const noop = () => undefined;
 
+const getMouseEventPoint = (e) => ({ x: e.pageX, y: e.pageY });
+const getTouchEventPoint = (e) => getMouseEventPoint(e.changedTouches[0]);
+export const getEventPoint = isTouch ? getTouchEventPoint : getMouseEventPoint;
+
+const getMouseEventTarget = (e) => e.target;
+const getTouchEventTarget = (e) => document.elementFromPoint(
+  e.changedTouches[0].clientX,
+  e.changedTouches[0].clientY,
+);
+export const getEventTarget = isTouch ? getTouchEventTarget : getMouseEventTarget;
+
 /**
  * TODO: explain why on earth you'd do something like this
  */

--- a/src/shared/functions/getRelativePoint.js
+++ b/src/shared/functions/getRelativePoint.js
@@ -1,3 +1,4 @@
-const getRelativePoint = (point, relative) => [point[0] - relative[0], point[1] - relative[1]];
+// useDrag now transforms the passed mouse/touch event and converts it to an Object => {x: , y: }
+const getRelativePoint = (point, relative) => [point.x - relative.x, point.y - relative.y];
 
 export default getRelativePoint;

--- a/src/shared/internal_hooks/useDrag.js
+++ b/src/shared/internal_hooks/useDrag.js
@@ -1,5 +1,6 @@
 import throttle from 'lodash.throttle';
 import { useRef, useCallback, useEffect } from 'react';
+import { Events, getEventPoint } from '../Constants';
 
 const defaultOptions = {
   /**
@@ -13,13 +14,6 @@ const defaultOptions = {
    */
   throttleBy: 0,
 };
-
-/**
- * Returns the click coordinates of a MouseEvent
- * @param event
- * @returns {*[]}
- */
-const getEventCoordinates = (event) => [event.clientX, event.clientY];
 
 /**
  * Create a persistent callback reference that will live trough a component lifecycle
@@ -94,7 +88,7 @@ const useDrag = (options = defaultOptions) => {
       info.isDragging = true;
       info.end = null;
       info.offset = null;
-      info.start = getEventCoordinates(event);
+      info.start = getEventPoint(event);
 
       if (dragStartHandlerRef.current) {
         dragStartHandlerRef.current(event, { ...info });
@@ -106,8 +100,9 @@ const useDrag = (options = defaultOptions) => {
    * Whilst dragging the element, updates the state then perform the user's onDrag handler if exists
    */
   const onDrag = useCallback(throttle((event) => {
+    const eventPoints = getEventPoint(event);
     if (info.isDragging) {
-      info.offset = [info.start[0] - event.clientX, info.start[1] - event.clientY];
+      info.offset = [info.start.x - eventPoints.x, info.start.y - eventPoints.y];
 
       if (dragHandlerRef.current) {
         dragHandlerRef.current(event, { ...info });
@@ -121,7 +116,7 @@ const useDrag = (options = defaultOptions) => {
   const onDragEnd = useCallback((event) => {
     if (info.isDragging) {
       info.isDragging = false;
-      info.end = getEventCoordinates(event);
+      info.end = getEventPoint(event);
 
       if (dragEndHandlerRef.current) {
         dragEndHandlerRef.current(event, { ...info });
@@ -140,16 +135,16 @@ const useDrag = (options = defaultOptions) => {
     /* eslint-enable no-underscore-dangle */
 
     if (targetRef.current) {
-      targetRef.current.addEventListener('mousedown', _onDragStart);
-      document.addEventListener('mousemove', _onDrag);
-      document.addEventListener('mouseup', _onDragEnd);
+      targetRef.current.addEventListener(Events.MOUSE_START, _onDragStart);
+      document.addEventListener(Events.MOUSE_MOVE, _onDrag);
+      document.addEventListener(Events.MOUSE_END, _onDragEnd);
     }
 
     return () => {
       if (targetRef.current) {
-        targetRef.current.removeEventListener('mousedown', _onDragStart);
-        document.removeEventListener('mousemove', _onDrag);
-        document.removeEventListener('mouseup', _onDragEnd);
+        targetRef.current.removeEventListener(Events.MOUSE_START, _onDragStart);
+        document.removeEventListener(Events.MOUSE_MOVE, _onDrag);
+        document.removeEventListener(Events.MOUSE_END, _onDragEnd);
       }
     };
   }, [targetRef.current]);


### PR DESCRIPTION
@antonioru I began this from the new Constants.js file you created for feature/canvas.

```
const getMouseEventPoint = (e) => ({ x: e.pageX, y: e.pageY });
const getTouchEventPoint = (e) => getMouseEventPoint(e.changedTouches[0]);
export const getEventPoint = isTouch ? getTouchEventPoint : getMouseEventPoint;
```

This now exposes the event point as an object instead of the usual array. I do like this as it's more explicit. However I started running into places where the array was still expected. I took the liberty of updating those areas to create/refer to an {x, y} object instead. Let me know if this makes sense or you'd rather revert to the [x, y] option.

*On another note I did notice that dragging the new canvas, creates a scroll. I had tackled something similar in the original PR #67 with `     touch-action: none;` inside diagram.scss. But since you're still working on the canvas feature, didn't want to try and address.

## Description
Add touch support for:
1. Dragging nodes
2. Dragging segments from nodes
3. Creating segments on _touchend_ at new port

## Related Issue
Closes #60 and replaces PR #67 

## Motivation and Context
Closes #60 

## How Has This Been Tested?
All existing tests are passing.
Tested on the Chrome mobile simulator on a mac and Safari on an iPad.
