### PR TITLE
Fixes breaking CI flow by inverting the execution order of external actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
-      - uses: gregoranders/nodejs-project-info@v0.0.11
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+      - uses: gregoranders/nodejs-project-info@v0.0.11
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
This PR fixes the improved CI flow brought in by #81 by inverting the execution order of external actions. I hadn't realized I could test the CI flow on my fork as the lack of configured secrets prevents all publishing steps from messing up the upstream repository.