### PR TITLE
Fix window scrolling when touch dragging to pan the canvas

### DIFF
--- a/src/components/Diagram/diagram.scss
+++ b/src/components/Diagram/diagram.scss
@@ -2,4 +2,6 @@
   box-sizing: border-box;
   width: 100%;
   height: 100%;
+  // Prevent touch dragging inside the diagram from scrolling the page
+  touch-action: none;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify diagram.scss to prevent default touch behavior from propagating from within the diagram. More info on touch-action:
https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action
Might have to reconsider if you're considering pinch to zoom as a way to zoom the canvas in mobile. We can look at that override when the time comes, since the default pinch to zoom behavior is too zoom in the whole page anyway, which is probably not desired.

## Motivation and Context
As part of the new touch support being worked on in canvas-ext

## How Has This Been Tested?
node dragging (no ports or links yet)
Chrome and Firefox in Mac.
Safari on an iPad.
